### PR TITLE
Loop jQuery object trough

### DIFF
--- a/js/jquery.keyboard.js
+++ b/js/jquery.keyboard.js
@@ -2287,6 +2287,6 @@ $.fn.caret = function( start, end ) {
 	}
 };
 
-return $keyboard;
+return $;
 
 }));


### PR DESCRIPTION
We are using your library in a current project with RequireJS. I spontaneously used your library directly instead of jQuery as follows:

```
require(
    [
        'keyboard',
    ],
    function($) {
        // jQuery now with keyboard plugin present 
    }
);
```

In the current version it does not work, because the jQuery object isn't returned. My changes "fixes" it.
